### PR TITLE
Made use of shared pointers for OD4 sessions

### DIFF
--- a/Receiver.cpp
+++ b/Receiver.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <memory>
 
 #include "cluon/OD4Session.hpp"
 #include "cluon/Envelope.hpp"
@@ -11,11 +12,12 @@
 
 class V2VReceiver {
 private:
-    cluon::OD4Session *platoonSession;
+    std::shared_ptr<cluon::OD4Session> broadcastSession;
+    std::shared_ptr<cluon::OD4Session> platoonSession;
 
 public:
     V2VReceiver() {
-        new cluon::OD4Session(BROADCAST_CHANNEL,
+        broadcastSession = std::make_shared<cluon::OD4Session>(BROADCAST_CHANNEL,
           [](cluon::data::Envelope &&envelope) noexcept {
               switch (envelope.dataType()) {
                   case ANNOUNCE_PRESENCE:    /*...*/
@@ -26,7 +28,7 @@ public:
 
     void joinPlatoon(uint8_t channel) {
         if (platoonSession != nullptr) platoonSession = nullptr;
-        platoonSession = new cluon::OD4Session(channel,
+        platoonSession = std::make_shared<cluon::OD4Session>(channel,
            [](cluon::data::Envelope &&envelope) noexcept {
                switch (envelope.dataType()) {
                    case ANNOUNCE_PRESENCE:  /*...*/
@@ -43,7 +45,7 @@ public:
 };
 
 int main(int /*argc*/, char ** /*argv*/) {
-    V2VReceiver *receiver = new V2VReceiver();
+    std::shared_ptr<V2VReceiver> receiver = std::make_shared<V2VReceiver>();
     receiver->joinPlatoon(DEMO_PLATOON_CHANNEL);
     
     using namespace std::chrono_literals; 

--- a/Sender.cpp
+++ b/Sender.cpp
@@ -2,6 +2,7 @@
 #include <chrono>
 #include <iostream>
 #include <unistd.h>
+#include <memory>
 
 #include "cluon/OD4Session.hpp"
 #include "cluon/Envelope.hpp"
@@ -10,12 +11,12 @@
 
 class V2VSender {
 private:
-    cluon::OD4Session *broadcastSession;
-    cluon::OD4Session *platoonSession;
+    std::shared_ptr<cluon::OD4Session> broadcastSession;
+    std::shared_ptr<cluon::OD4Session> platoonSession;
 
 public:
     V2VSender() {
-        broadcastSession = new cluon::OD4Session(BROADCAST_CHANNEL,
+        broadcastSession = std::make_shared<cluon::OD4Session>(BROADCAST_CHANNEL,
                                [](cluon::data::Envelope /*&&envelope*/) noexcept {});
     }
 
@@ -26,7 +27,7 @@ public:
     }
 
     void followRequest(uint8_t channel, uint8_t carId) {
-        platoonSession = new cluon::OD4Session(channel,
+        platoonSession = std::make_shared<cluon::OD4Session>(channel,
                              [](cluon::data::Envelope /*&&envelope*/) noexcept {});
         FollowRequest fr;
         fr.carId(carId);
@@ -74,7 +75,8 @@ public:
 };
 
 int main(int /*argc*/, char ** /*argv*/) {
-    V2VSender *sender = new V2VSender();
+    std::shared_ptr<V2VSender> sender = std::make_shared<V2VSender>();
+    
     while (1) {
         int choice;
         std::cout << "Which message would you like to send?" << std::endl;


### PR DESCRIPTION
As per our feedback I have added shared pointers instead of raw ones. One thing still perplexes me a bit though. Not adding the broadcast session for the sender class as a class variable did not work as before with new. I would not receive messages on the broadcast channel (annouce presence that is) until adding the class variable to hold a reference to the session. Anyone have any input on this?